### PR TITLE
fix demo delay with sp cm exec

### DIFF
--- a/cats/sp_cm.cfg
+++ b/cats/sp_cm.cfg
@@ -22,4 +22,4 @@ sar_cm_rightwarp 1
 
 // Category-specific aliases
 sar_alias do_load nop
-sar_alias do_reset "restart_level"
+sar_alias do_reset "stop; restart_level"


### PR DESCRIPTION
not sure if  `sar_challenge_autostop 1` is meant to prevent demo delay but if it is supposed to stop demos every time you restart level it doesn't seem to be working properly